### PR TITLE
Steam::API DRY, fix User#profile_url, Leaderboard#url

### DIFF
--- a/src/cr/model/leaderboard.rb
+++ b/src/cr/model/leaderboard.rb
@@ -32,7 +32,7 @@ module ChelshiaRocks
 
     # URL to this leaderboard's Steam page
     def url
-      "#{Steam::API::BASE_URL}/stats/#{app_id}/leaderboards/#{leaderboard_id}"
+      "#{Steam::API::COMMUNITY_URL}/stats/#{app_id}/leaderboards/#{leaderboard_id}"
     end
 
     # The most recent entries for this board

--- a/src/cr/model/user.rb
+++ b/src/cr/model/user.rb
@@ -27,7 +27,7 @@ module ChelshiaRocks
 
     # URL to this user's steam profile
     def profile_url
-      "#{Steam::API::BASE_URL}/profiles/#{steam_id}"
+      "#{Steam::API::COMMUNITY_URL}/profiles/#{steam_id}"
     end
 
     # This user's latest entry on a board

--- a/src/cr/steam.rb
+++ b/src/cr/steam.rb
@@ -6,6 +6,18 @@ module Steam
   module API
     module_function
 
+    # Generic GET request handler
+    # @param route [String] the route to send a request to
+    # @param params [Hash] querystring parameters
+    # @param parser [Symbol] either :json or :xml will parse using those parsers. Any other value (nil) returns the raw response
+    def get(route = '', params = {}, parser = :json)
+      response = RestClient.get(route, params: params)
+
+      return JSON.parse(response, symbolize_name: true) if parser == :json
+      return XmlSimple.xml_in(response, keytosymbol: true, forcearray: false) if parser == :xml
+      response
+    end
+
     # Get one or more users by Steam ID
     # @param steam_id [Integer, String, Array<Integer, String>] One or more Steam ID's
     # @return [Array<Hash>]

--- a/src/cr/steam.rb
+++ b/src/cr/steam.rb
@@ -4,6 +4,12 @@ require 'json'
 
 module Steam
   module API
+    # URL of the official Steam API
+    API_URL = 'https://api.steampowered.com'.freeze
+
+    # URL of Steam's community site
+    COMMUNITY_URL = 'https://steamcommunity.com'.freeze
+
     module_function
 
     # Generic GET request handler
@@ -23,14 +29,13 @@ module Steam
     # @return [Array<Hash>]
     def user(steam_id)
       ids = steam_id.is_a?(Array) ? steam_id.join(',') : steam_id
-      response =
-        RestClient.get "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/",
-          params: {
-            key: ENV['STEAM_API_KEY'],
-            steamids: ids
-          }
-        json = JSON.parse(response, symbolize_names: true)
-        json[:response][:players]
+      response = get "#{API_URL}/ISteamUser/GetPlayerSummaries/v0002/",
+                     {
+                       key: ENV['STEAM_API_KEY'],
+                       steamids: ids
+                     },
+                     :json
+      response[:response][:players]
     end
 
     # Get a leaderboard
@@ -40,15 +45,14 @@ module Steam
     # @param _end [Integer] index end of paginated responses
     # @return [Hash]
     def leaderboard(app_id, id, index_start = 1, index_end = 100)
-      response =
-        RestClient.get "http://steamcommunity.com/stats/#{app_id}/leaderboards/#{id}",
-          params: {
+      get "#{COMMUNITY_URL}/stats/#{app_id}/leaderboards/#{id}",
+          {
             xml: 1,
             start: index_start,
             end: index_end,
             t: Time.now.to_i
-        }
-      XmlSimple.xml_in(response, keytosymbol: true, forcearray: false)
+          },
+          :xml
     end
   end
 end


### PR DESCRIPTION
- Re-implements the generic GET handler for DRY in `Steam::API`
- fixes `User#profile_url`
- fixes `Leaderboard#url`